### PR TITLE
Changed logic of default radius and current radius

### DIFF
--- a/models/default_radii.sql
+++ b/models/default_radii.sql
@@ -3,8 +3,8 @@ WITH default_radii AS(
         delivery_area_id,
         time_from AS event_started_timestamp,
         time_to AS event_ended_timestamp,
-        radius_from AS default_radius
+        current_radius AS default_radius
     FROM {{ ref('radius_change_history') }}
-    WHERE default_radius = 'Yes'
+
 )
 SELECT * FROM default_radii

--- a/models/radius_change_history.sql
+++ b/models/radius_change_history.sql
@@ -3,15 +3,21 @@ WITH default_radius AS(
     delivery_area_id,
     time_from,
     time_to,
-    radius_from,
-    radius_to,
+    current_radius,
+    last_known_radius,
     time_to-time_from AS duration,
-    radius_to-radius_from AS radius_change,
+    current_radius-last_known_radius AS radius_change,
     CASE
-      WHEN EXTRACT( HOUR FROM (time_to-time_from)) >= 24
+      WHEN EXTRACT( HOUR FROM (time_to-time_from)) < 24
       THEN 'Yes'
       ELSE 'No'
-    END AS default_radius
+    END AS is_temporary_change,
+    CASE 
+      WHEN EXTRACT( HOUR FROM (time_to-time_from)) > 24
+      THEN current_radius
+      ELSE last_known_radius
+    END AS default_radius_value
+    
   FROM {{ ref('transformed_radius_log') }}
   ORDER BY delivery_area_id, time_from
 )

--- a/models/transformed_radius_log.sql
+++ b/models/transformed_radius_log.sql
@@ -3,8 +3,8 @@ WITH radius_change_history AS(
         delivery_area_id,
         event_started_timestamp AS time_from,
         COALESCE(LEAD(event_started_timestamp) OVER(PARTITION BY delivery_area_id ORDER BY event_started_timestamp), event_started_timestamp) AS time_to,
-        delivery_radius_meters AS radius_from,
-        COALESCE(LEAD(delivery_radius_meters) OVER(PARTITION BY delivery_area_id ORDER BY event_started_timestamp), delivery_radius_meters) AS radius_to
+        delivery_radius_meters AS current_radius,
+        COALESCE(LAG(delivery_radius_meters) OVER(PARTITION BY delivery_area_id ORDER BY event_started_timestamp), delivery_radius_meters) AS last_known_radius
 
     FROM {{ ref('src_delivery_radius_log') }}
 )


### PR DESCRIPTION
Before: Default radius was an extract out of the data wherever a radius change lasted for >= 24 hrs
Now: Default radius now is embedded in transformed delivery log data (radius_change_history.sql) to have another default radius value which shall contain the current value if duration >=24hrs otherwise last known radius value (previous radius) 