### PR TITLE
Default Radii periods changed

### DIFF
--- a/models/default_radii.sql
+++ b/models/default_radii.sql
@@ -1,10 +1,11 @@
 WITH default_radii AS(
-    SELECT
-        delivery_area_id,
-        time_from AS event_started_timestamp,
-        time_to AS event_ended_timestamp,
-        current_radius AS default_radius
-    FROM {{ ref('radius_change_history') }}
-
+  SELECT 
+    delivery_area_id,
+    time_from AS event_started_timestamp,
+    LEAD(time_from) OVER(PARTITION BY delivery_area_id ORDER BY time_from) AS event_ended_timstamp,
+    default_radius_value AS default_radius
+  FROM {{ ref('radius_change_history') }}
+  WHERE is_temporary_change='No'
+  ORDER BY delivery_area_id,time_from
 )
-SELECT * FROM default_radii
+SELECT * FROM default_radii 


### PR DESCRIPTION
Added more depth in analysis by picking by records which are not temporary radius change from the radius_change_history table. Also deriving the event_ended_timestamp value from lead value of time_from (event_started) 